### PR TITLE
Allow modern versions of "requests"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(name='gauthify',
       author_email='support@gauthify.com',
       license='MIT',
       install_requires=[
-          'requests==0.14.1',
+          'requests>=0.14.1',
       ],
       packages=['gauthify'],
       zip_safe=False)


### PR DESCRIPTION
Otherwise, installing the package may result in deletion of the currently installed version of 'requests'.

As a general question, what's the status of this package, and of GAuthify in general? There was no recent activity here on Github and on Twitter. Is the project still being maintained?
